### PR TITLE
Add ability to read IO types

### DIFF
--- a/src/JBDF.jl
+++ b/src/JBDF.jl
@@ -7,8 +7,17 @@ function readBdf(fname::String; from::Real=0, to::Real=-1)
     #from: start time in seconds, default is 0
     #to: end time, default is the full duration
     #returns data, trigChan, sysCodeChan, evtTab
- 
-    fid = open(fname, "r")
+
+    readBdf(open(fname, "r"), from=from, to=to)
+end
+
+
+function readBdf(fid::IO; from::Real=0, to::Real=-1)
+
+    if isa(fid, IOBuffer)
+        fid.ptr = 1
+    end
+
     idCodeNonASCII = read(fid, Uint8, 1)
     idCode = ascii(read(fid, Uint8, 7))
     subjID = ascii(read(fid, Uint8, 80))


### PR DESCRIPTION
This allows reading directly from S3 using AWS.jl

``` julia
using JBDF
using AWS
using AWS.S3

# Local control file
dats, evtTab, trigs, statusChan = readBdf("BDFtestfiles/Newtest17-2048.bdf")

# Read file from AWS
env = AWSEnv(xxx)
bkt = "xxx"
fle2 = "BDFtestfiles/Newtest17-2048.bdf"
resp = S3.get_object(env, bkt, fle2);
dats2, evtTab2, trigs2, statusChan2 = readBdf(resp.obj)

# Do the files match
println(isequal(dats, dats2))
>>> true
```
