### PR TITLE
Update module and filename to BDF.jl format

### DIFF
--- a/src/BDF.jl
+++ b/src/BDF.jl
@@ -1,4 +1,4 @@
-module JBDF
+module BDF
 
 export readBdf, readBdfHeader, writeBdf, splitBdfAtTrigger
 


### PR DESCRIPTION
This may break older scripts!

The change was required for my julia(v0.3) installation to see your new repo name.
