### PR TITLE
Enable tagbot

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.COMPATHELPER_PRIV }}


### PR DESCRIPTION
Following #21 it would be handy to release a new version so that downstream packages can use BDF.jl

I dont know how to release versions manually, I always just use this bot.